### PR TITLE
feat: a few minor utilities

### DIFF
--- a/Runtime/Core/Extensions/PrimitivesExtensions.cs
+++ b/Runtime/Core/Extensions/PrimitivesExtensions.cs
@@ -2,11 +2,14 @@ using andywiecko.BurstCollections;
 using andywiecko.BurstMathUtils;
 using System;
 using Unity.Mathematics;
+using UnityEngine;
 
 namespace andywiecko.PBD2D.Core
 {
     public static class PrimitivesExtensions
     {
+        public static AABB ToAABB(this Bounds bounds) => new(bounds.min.ToFloat2(), bounds.max.ToFloat2());
+
         public static float2 GetPoint(this AABB aabb, int i) => i switch
         {
             0 => aabb.Min,

--- a/Runtime/Core/Structs/Helpers/IdPair.cs
+++ b/Runtime/Core/Structs/Helpers/IdPair.cs
@@ -1,17 +1,19 @@
 using andywiecko.BurstCollections;
+using System;
 
 namespace andywiecko.PBD2D.Core
 {
-    public readonly struct IdPair<T>
+    public readonly struct IdPair<T> : IEquatable<IdPair<T>>
     {
         public readonly Id<T> Id1, Id2;
         public IdPair(Id<T> id1, Id<T> id2) => (Id1, Id2) = (id1, id2);
         public readonly void Deconstruct(out Id<T> id1, out Id<T> id2) => (id1, id2) = (Id1, Id2);
         public static implicit operator IdPair<T>((Id<T> id1, Id<T> id2) tuple) => new(tuple.id1, tuple.id2);
         public override string ToString() => $"({Id1}, {Id2})";
+        public bool Equals(IdPair<T> other) => Id1 == other.Id1 && Id2 == other.Id2;
     }
 
-    public readonly struct IdPair<T1, T2>
+    public readonly struct IdPair<T1, T2> : IEquatable<IdPair<T1, T2>>
     {
         public readonly Id<T1> Id1;
         public readonly Id<T2> Id2;
@@ -19,5 +21,6 @@ namespace andywiecko.PBD2D.Core
         public readonly void Deconstruct(out Id<T1> id1, out Id<T2> id2) => (id1, id2) = (Id1, Id2);
         public static implicit operator IdPair<T1, T2>((Id<T1> id1, Id<T2> id2) tuple) => new(tuple.id1, tuple.id2);
         public override string ToString() => $"({Id1}, {Id2})";
+        public bool Equals(IdPair<T1, T2> other) => Id1 == other.Id1 && Id2 == other.Id2;
     }
 }

--- a/Runtime/Core/Structs/Primitives/Edge.cs
+++ b/Runtime/Core/Structs/Primitives/Edge.cs
@@ -19,10 +19,12 @@ namespace andywiecko.PBD2D.Core
             0.5f * (positions[edge.IdA] + positions[edge.IdB]);
         public static float2 GetCenter<T>(this T edge, NativeIndexedArray<Id<Point>, float2> positions) where T : unmanaged, IEdge =>
             GetCenter(edge, positions.AsReadOnly());
+        public static float GetLength<T>(this T edge, ReadOnlySpan<float2> positions) where T : unmanaged, IEdge =>
+            math.distance(positions[(int)edge.IdA], positions[(int)edge.IdB]);
         public static float GetLength<T>(this T edge, NativeIndexedArray<Id<Point>, float2>.ReadOnly positions) where T : unmanaged, IEdge =>
-            math.distance(positions[edge.IdA], positions[edge.IdB]);
+            GetLength(edge, positions.AsReadOnlySpan());
         public static float GetLength<T>(this T edge, NativeIndexedArray<Id<Point>, float2> positions) where T : unmanaged, IEdge =>
-            GetLength(edge, positions.AsReadOnly());
+            GetLength(edge, positions.AsReadOnlySpan());
         public static AABB ToAABB<T>(this T edge, NativeIndexedArray<Id<Point>, float2>.ReadOnly positions, float margin = 0)
             where T : unmanaged, IEdge
         {

--- a/Runtime/Core/Utils/GizmosUtils.cs
+++ b/Runtime/Core/Utils/GizmosUtils.cs
@@ -1,3 +1,4 @@
+using andywiecko.BurstCollections;
 using andywiecko.BurstMathUtils;
 using Unity.Mathematics;
 using UnityEngine;
@@ -16,6 +17,8 @@ namespace andywiecko.PBD2D.Core
             DrawLine(b, c, z);
             DrawLine(c, a, z);
         }
+
+        public static void DrawAABB(AABB aabb, float z = 0) => DrawRectangle(aabb.Min, aabb.Max, z);
 
         public static void DrawRectangle(float2 min, float2 max, float z = 0)
         {


### PR DESCRIPTION
- `ToAABB` extension for `UnityEngine.Bounds`;
- `IdPair<,>` implements `IEquatable` interface;
-  `GetLength` extension using `ReadOnlySpan` for `IEdge`;
- `GizmoUtils` for `AABB`.