### PR TITLE
feat: points locker entity

### DIFF
--- a/Runtime/Components/PointsLocker.meta
+++ b/Runtime/Components/PointsLocker.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b053f8a418a15ef4d8e1d0535d529387
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Components/PointsLocker/PointsLocker.cs
+++ b/Runtime/Components/PointsLocker/PointsLocker.cs
@@ -1,0 +1,65 @@
+using andywiecko.BurstCollections;
+using andywiecko.ECS;
+using andywiecko.PBD2D.Core;
+using System;
+using Unity.Collections;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace andywiecko.PBD2D.Components
+{
+    public class PointsLocker : Entity
+    {
+        public event Action OnTransformChanged;
+        public Ref<NativeArray<Point>> Points => Target.Points;
+        public Ref<NativeIndexedArray<Id<Point>, float2>> Positions => Target.Positions;
+        public Ref<NativeIndexedArray<Id<Point>, float>> Weights => Target.Weights;
+
+        private IPointsProvider Target { get; set; }
+        [SerializeField, Tooltip("All entities which implement `" + nameof(IPointsProvider) + "` can be set as target.")]
+        private Entity target = default;
+
+        private RigidTransform RigidTransform => new(transform.rotation, transform.position);
+        private RigidTransform previousRigidTransform;
+
+        protected override void Awake()
+        {
+            base.Awake();
+            Target = target as IPointsProvider;
+            previousRigidTransform = RigidTransform;
+
+            if (Target == null)
+            {
+                foreach (var c in GetComponents<BaseComponent>())
+                {
+                    c.enabled = false;
+                }
+                throw new NullReferenceException();
+            }
+        }
+
+        private void Update()
+        {
+            if (!RigidTransform.Equals(previousRigidTransform))
+            {
+                OnTransformChanged?.Invoke();
+            }
+
+            previousRigidTransform = RigidTransform;
+        }
+
+        private void OnValidate()
+        {
+            if (target != null && target is not IPointsProvider)
+            {
+                Debug.LogError(
+                    $"[{name}]: Type {target.GetType()} is not supported! " +
+                    $"Use component which implements `{nameof(IPointsProvider)}`.",
+                    this
+                );
+                target = default;
+                return;
+            }
+        }
+    }
+}

--- a/Runtime/Components/PointsLocker/PointsLocker.cs.meta
+++ b/Runtime/Components/PointsLocker/PointsLocker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4728864b17cb1046a855bb88cccfd17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Components/TriMesh/Base/TriMesh.cs
+++ b/Runtime/Components/TriMesh/Base/TriMesh.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace andywiecko.PBD2D.Components
 {
-    public class TriMesh : Entity
+    public class TriMesh : Entity, IPointsProvider
     {
         public event Action OnSerializedDataChange;
 

--- a/Runtime/Core/Contracts/Contracts.Constraints.cs
+++ b/Runtime/Core/Contracts/Contracts.Constraints.cs
@@ -6,6 +6,13 @@ using Unity.Mathematics;
 
 namespace andywiecko.PBD2D.Core
 {
+    public interface IPointsProvider
+    {
+        Ref<NativeArray<Point>> Points { get; }
+        Ref<NativeIndexedArray<Id<Point>, float2>> Positions { get; }
+        Ref<NativeIndexedArray<Id<Point>, float>> Weights { get; }
+    }
+
     public interface IPositionConstraints : IComponent
     {
         float Stiffness { get; }


### PR DESCRIPTION
Introduces a new entity type.
Points locker can be used to lock points positions during runtime (statically or dynamically).