### PR TITLE
feat: edge mesh entity

### DIFF
--- a/Editor/EdgeMeshEditor.cs
+++ b/Editor/EdgeMeshEditor.cs
@@ -1,0 +1,64 @@
+﻿using andywiecko.ECS.Editor;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace andywiecko.PBD2D.Components
+{
+    [CustomEditor(typeof(EdgeMesh))]
+    public class EdgeMeshEditor : EntityEditor
+    {
+        private Label label;
+        private EdgeMesh edgeMesh;
+
+        private void OnEnable()
+        {
+            label = CreateLabel();
+            UpdateLabel();
+            edgeMesh = target as EdgeMesh;
+            edgeMesh.OnSerializedDataChange += UpdateLabel;
+        }
+
+        private void OnDisable()
+        {
+            edgeMesh.OnSerializedDataChange -= UpdateLabel;
+        }
+
+        public override VisualElement CreateInspectorGUI()
+        {
+            var root = base.CreateInspectorGUI();
+
+            var serializedData = serializedObject.FindProperty($"<{nameof(EdgeMesh.SerializedData)}>k__BackingField");
+            var serializedDataProperty = new PropertyField(serializedData);
+            serializedDataProperty.SetEnabled(!Application.isPlaying);
+            root.Insert(1, serializedDataProperty);
+
+            root.Insert(2, label);
+
+            return root;
+        }
+
+        private Label CreateLabel() => new()
+        {
+            style =
+                {
+                    borderBottomColor = new StyleColor(Color.white), borderBottomWidth = 1,
+                    borderLeftColor = new StyleColor(Color.white), borderLeftWidth = 1,
+                    borderRightColor = new StyleColor(Color.white), borderRightWidth = 1,
+                    borderTopColor = new StyleColor(Color.white), borderTopWidth = 1,
+                    marginTop = 15, marginBottom = 15,
+                    paddingTop = 5, paddingBottom = 5, fontSize = 13
+                }
+        };
+
+        private void UpdateLabel()
+        {
+            var data = (target as EdgeMesh).SerializedData;
+            var points = data == null ? "???" : data.Positions.Length.ToString();
+            var triangles = data == null ? "???" : (data.Edges.Length / 2).ToString();
+
+            label.text = $" Data:  ● Points: {points}  | Edges: {triangles}  ";
+        }
+    }
+}

--- a/Editor/EdgeMeshEditor.cs.meta
+++ b/Editor/EdgeMeshEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 64e81d702d52ae74bb7f68b835168f30
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - styleSheet: {fileID: 7433441132597879392, guid: 9ff5cb1686dd0ce4e84b0b7be1f62d68, type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Components/EdgeMesh.meta
+++ b/Runtime/Components/EdgeMesh.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6971c415672a0f34d89ba46f722eab88
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Components/EdgeMesh/Base.meta
+++ b/Runtime/Components/EdgeMesh/Base.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 955204709ee5ff14495d1b0a0fb3b85e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Components/EdgeMesh/Base/EdgeMesh.cs
+++ b/Runtime/Components/EdgeMesh/Base/EdgeMesh.cs
@@ -1,0 +1,114 @@
+using andywiecko.BurstCollections;
+using andywiecko.ECS;
+using andywiecko.PBD2D.Core;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using Unity.Collections;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace andywiecko.PBD2D.Components
+{
+    public class EdgeMesh : Entity, IPointsProvider
+    {
+        public event Action OnSerializedDataChange;
+
+        [field: SerializeField, HideInInspector]
+        public EdgeMeshSerializedData SerializedData { get; private set; } = default;
+        private EdgeMeshSerializedData serializedData;
+
+        public IPhysicalMaterial PhysicalMaterial => physicalMaterial ? physicalMaterial : Core.PhysicalMaterial.Default;
+        [SerializeField]
+        private PhysicalMaterial physicalMaterial = default;
+
+        public Ref<NativeArray<Point>> Points { get; private set; }
+        public Ref<NativeIndexedArray<Id<Point>, float>> Weights { get; private set; }
+        public Ref<NativeIndexedArray<Id<Point>, float2>> Positions { get; private set; }
+        public Ref<NativeIndexedArray<Id<Point>, float2>> PreviousPositions { get; private set; }
+        public Ref<NativeIndexedArray<Id<Point>, float2>> Velocities { get; private set; }
+        public Ref<NativeIndexedArray<Id<Edge>, Edge>> Edges { get; private set; }
+
+        protected override void Awake()
+        {
+            base.Awake();
+
+            if (!SerializedData)
+            {
+                foreach (var c in GetComponents<BaseComponent>())
+                {
+                    c.enabled = false;
+                }
+                throw new NullReferenceException();
+            }
+
+            var s = transform.localScale;
+            var rb = new RigidTransform(transform.rotation, transform.position);
+            float2 T(float2 x) => math.transform(rb, s * (x.ToFloat3() - rb.pos) + s * rb.pos).xy;
+            var transformedPositions = SerializedData.ToPositions(transformation: T);
+            var pointsCount = SerializedData.Positions.Length;
+
+            var allocator = Allocator.Persistent;
+            DisposeOnDestroy(
+                Points = new NativeArray<Point>(SerializedData.ToPoints(), allocator),
+                Weights = new NativeIndexedArray<Id<Point>, float>(SerializedData.ToWeights(transformation: T, PhysicalMaterial.Density), allocator),
+                Positions = new NativeIndexedArray<Id<Point>, float2>(transformedPositions, allocator),
+                PreviousPositions = new NativeIndexedArray<Id<Point>, float2>(transformedPositions, allocator),
+                Velocities = new NativeIndexedArray<Id<Point>, float2>(pointsCount, allocator),
+                Edges = new NativeIndexedArray<Id<Edge>, Edge>(SerializedData.ToEdges(), allocator)
+            );
+        }
+
+        private void OnValidate()
+        {
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.delayCall += DelayedOnValidate;
+#endif
+        }
+
+        private void DelayedOnValidate()
+        {
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.delayCall -= DelayedOnValidate;
+#endif
+            if (SerializedData != serializedData)
+            {
+                OnSerializedDataChange?.Invoke();
+                serializedData = SerializedData;
+            }
+        }
+
+        private void OnDrawGizmos()
+        {
+            if (!SerializedData)
+            {
+                return;
+            }
+
+            var rb = new RigidTransform(transform.rotation, transform.position);
+            var s = transform.localScale.ToFloat4().xyz;
+            float2 T(float2 x) => Application.isPlaying ? x : math.transform(rb, s * (x.ToFloat3() - rb.pos) + s * rb.pos).xy;
+
+            ReadOnlySpan<float2> positions = Application.isPlaying ? Positions.Value : SerializedData.Positions;
+            foreach (var p in positions)
+            {
+                GizmosUtils.DrawCircle(T(p), r: 0.05f);
+            }
+
+            IEnumerable<(int, int)> edges = Application.isPlaying ?
+                Edges.Value.Select(i => ((int)i.IdA, (int)i.IdB)) :
+                Enumerable
+                    .Range(0, SerializedData.Edges.Length / 2)
+                    .Select(i =>
+                    {
+                        var e = SerializedData.Edges;
+                        return (e[2 * i], e[2 * i + 1]);
+                    });
+
+            foreach (var (eA, eB) in edges)
+            {
+                GizmosUtils.DrawLine(T(positions[eA]), T(positions[eB]));
+            }
+        }
+    }
+}

--- a/Runtime/Components/EdgeMesh/Base/EdgeMesh.cs.meta
+++ b/Runtime/Components/EdgeMesh/Base/EdgeMesh.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 575cb6f24217eae46944e356c56b7022
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedData.cs
+++ b/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedData.cs
@@ -1,0 +1,11 @@
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace andywiecko.PBD2D.Components
+{
+    public abstract class EdgeMeshSerializedData : ScriptableObject
+    {
+        [field: SerializeField, HideInInspector] public float2[] Positions { get; protected set; } = { };
+        [field: SerializeField, HideInInspector] public int[] Edges { get; protected set; } = { };
+    }
+}

--- a/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedData.cs.meta
+++ b/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46e1eafc1e306f54e9aa808d74a3ea7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedDataExtensions.cs
+++ b/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedDataExtensions.cs
@@ -1,0 +1,41 @@
+using andywiecko.BurstCollections;
+using andywiecko.PBD2D.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.Mathematics;
+
+namespace andywiecko.PBD2D.Components
+{
+    public static class EdgeMeshSerializedDataExtensions
+    {
+        public static Point[] ToPoints(this EdgeMeshSerializedData data) => Enumerable
+            .Range(0, data.Positions.Length).Select(i => new Point((Id<Point>)i)).ToArray();
+
+        public static float2[] ToPositions(this EdgeMeshSerializedData data, Func<float2, float2> transformation) =>
+            data.Positions.Select(i => transformation(i)).ToArray();
+
+        public static float[] ToWeights(this EdgeMeshSerializedData data, Func<float2, float2> transformation, float density)
+        {
+            var pointsCount = data.Positions.Length;
+            var weights = new float[pointsCount];
+            var positions = data.ToPositions(transformation);
+            foreach (var e in data.GetEdges())
+            {
+                var (a, b) = e;
+                var length = e.GetLength(positions);
+                var w0 = 2f / density / length; // 2 (points)
+                weights[(int)a] += w0;
+                weights[(int)b] += w0;
+            }
+
+            return weights;
+        }
+
+        public static Edge[] ToEdges(this EdgeMeshSerializedData data) => data.GetEdges().ToArray();
+
+        private static IEnumerable<Edge> GetEdges(this EdgeMeshSerializedData data) => Enumerable
+            .Range(0, data.Edges.Length / 2)
+            .Select(i => (Edge)(data.Edges[2 * i], data.Edges[2 * i + 1]));
+    }
+}

--- a/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedDataExtensions.cs.meta
+++ b/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedDataExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efdebe5565b7d43459ef6a34992cb363
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedDataLine.cs
+++ b/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedDataLine.cs
@@ -1,0 +1,49 @@
+using System;
+using UnityEngine;
+
+namespace andywiecko.PBD2D.Components
+{
+    [CreateAssetMenu(
+        fileName = "EdgeMeshSerializedDataLine",
+        menuName = "PBD2D/EdgeMesh/Serialized Data (Line)"
+    )]
+    public class EdgeMeshSerializedDataLine : EdgeMeshSerializedData
+    {
+        [SerializeField, Min(2)]
+        private int samples = 10;
+
+        [SerializeField, Min(1e-9f)]
+        private float length = 1;
+
+        private void Awake()
+        {
+            GeneratePoints();
+        }
+
+        private void OnValidate()
+        {
+            GeneratePoints();
+        }
+
+        private void GeneratePoints()
+        {
+            var p = Positions;
+            Array.Resize(ref p, samples);
+            var dx = length / (samples - 1);
+            for (int i = 0; i < p.Length; i++)
+            {
+                p[i] = new(i * dx, 0);
+            }
+            Positions = p;
+
+            var e = Edges;
+            Array.Resize(ref e, 2 * (samples - 1));
+            for (int i = 0; i < samples - 1; i++)
+            {
+                e[2 * i + 0] = i + 0;
+                e[2 * i + 1] = i + 1;
+            }
+            Edges = e;
+        }
+    }
+}

--- a/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedDataLine.cs.meta
+++ b/Runtime/Components/EdgeMesh/Base/EdgeMeshSerializedDataLine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7fca7cbac56e9546a69ecb03ec63e18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Introduces a new entity: `EdgeMesh`, which is used for one-dimensional structures, like rods/trees/etc. MR contains simple implementation of `EdgeMeshSerializedData` for storing data of straight line of points.