### PR TITLE
fix: trimesh renderer transform

### DIFF
--- a/Runtime/Components/TriMesh/Base/TriMesh.cs
+++ b/Runtime/Components/TriMesh/Base/TriMesh.cs
@@ -43,9 +43,7 @@ namespace andywiecko.PBD2D.Components
                 throw new NullReferenceException();
             }
 
-            var s = transform.localScale;
-            var rb = new RigidTransform(transform.rotation, transform.position);
-            float2 T(float2 x) => math.transform(rb, s * (x.ToFloat3() - rb.pos) + s * rb.pos).xy;
+            float2 T(float2 x) => math.mul((float4x4)transform.localToWorldMatrix, math.float4(x, 1, 1)).xy;
             var transformedPositions = SerializedData.ToPositions(transformation: T);
             var pointsCount = SerializedData.Positions.Length;
 
@@ -59,9 +57,6 @@ namespace andywiecko.PBD2D.Components
                 Edges = new NativeIndexedArray<Id<Edge>, Edge>(SerializedData.ToEdges(), allocator),
                 Triangles = new NativeIndexedArray<Id<Triangle>, Triangle>(SerializedData.ToTriangles(), allocator)
             );
-
-            transform.SetPositionAndRotation(default, quaternion.identity);
-            transform.localScale = (float3)1;
         }
 
         private void OnValidate()
@@ -90,9 +85,7 @@ namespace andywiecko.PBD2D.Components
                 return;
             }
 
-            var rb = new RigidTransform(transform.rotation, transform.position);
-            var s = transform.localScale.ToFloat4().xyz;
-            float2 T(float2 x) => Application.isPlaying ? x : math.transform(rb, s * (x.ToFloat3() - rb.pos) + s * rb.pos).xy;
+            float2 T(float2 x) => Application.isPlaying ? x : math.mul((float4x4)transform.localToWorldMatrix, math.float4(x, 1, 1)).xy;
 
             ReadOnlySpan<float2> positions = Application.isPlaying ? Positions.Value : SerializedData.Positions;
             Gizmos.color = 0.7f * Color.yellow + 0.3f * Color.green;

--- a/Runtime/Components/TriMesh/Graphics/TriMeshRenderer.cs
+++ b/Runtime/Components/TriMesh/Graphics/TriMeshRenderer.cs
@@ -13,6 +13,7 @@ namespace andywiecko.PBD2D.Components
     [Category(PBDCategory.Graphics)]
     public class TriMeshRenderer : BaseComponent, ITriMeshRenderer
     {
+        public float4x4 WorldToLocal => transform.worldToLocalMatrix;
         public Mesh Mesh { get; private set; }
         public Ref<NativeArray<float3>> MeshVertices { get; private set; }
         public Ref<NativeIndexedArray<Id<Point>, float2>> Positions => triMesh.Positions;
@@ -37,6 +38,7 @@ namespace andywiecko.PBD2D.Components
                 rendererTransform = new GameObject(name).transform;
                 rendererTransform.SetParent(transform);
                 rendererTransform.localPosition = float3.zero;
+                rendererTransform.localRotation = quaternion.identity;
                 rendererTransform.localScale = (float3)1;
             }
 
@@ -84,11 +86,10 @@ namespace andywiecko.PBD2D.Components
             TryCreateRenderer();
 
             triMesh = GetComponent<TriMesh>();
-            rendererTransform.SetPositionAndRotation(float3.zero, quaternion.identity);
             var meshFilter = rendererTransform.GetComponent<MeshFilter>();
             Mesh = meshFilter.mesh;
 
-            var vertices = triMesh.Positions.Value.Select(i => i.ToFloat3()).ToArray();
+            var vertices = triMesh.Positions.Value.Select(i => math.mul(WorldToLocal, math.float4(i, 1, 1)).xyz).ToArray();
             DisposeOnDestroy(
                 MeshVertices = new NativeArray<float3>(vertices, Allocator.Persistent)
             );

--- a/Runtime/Core/Contracts/Contracts.Graphics.cs
+++ b/Runtime/Core/Contracts/Contracts.Graphics.cs
@@ -8,6 +8,7 @@ namespace andywiecko.PBD2D.Core
 {
     public interface ITriMeshRenderer : IComponent
     {
+        float4x4 WorldToLocal { get; }
         Mesh Mesh { get; }
         Ref<NativeIndexedArray<Id<Point>, float2>> Positions { get; }
         Ref<NativeArray<float3>> MeshVertices { get; }

--- a/Runtime/Systems/Graphics/TriMeshRendererSystem.cs
+++ b/Runtime/Systems/Graphics/TriMeshRendererSystem.cs
@@ -14,17 +14,19 @@ namespace andywiecko.PBD2D.Systems
         [BurstCompile]
         private struct CopyPositionsToMeshVerticesJob : IJobParallelFor
         {
+            private readonly float4x4 w2l;
             private NativeArray<float3> vertices;
             private NativeIndexedArray<Id<Point>, float2>.ReadOnly positions;
 
             public CopyPositionsToMeshVerticesJob(ITriMeshRenderer renderer)
             {
+                w2l = renderer.WorldToLocal;
                 vertices = renderer.MeshVertices.Value;
                 positions = renderer.Positions.Value.AsReadOnly();
             }
 
             public JobHandle Schedule(JobHandle dependencies) => this.Schedule(vertices.Length, 64, dependencies);
-            public void Execute(int index) => vertices[index] = positions[(Id<Point>)index].ToFloat3();
+            public void Execute(int index) => vertices[index] = math.mul(w2l, math.float4(positions[(Id<Point>)index], 1, 1)).xyz;
         }
 
         [SolverAction]


### PR DESCRIPTION
Resolves the bug related to bad transformation of trimesh renderer. For now `TriMesh` as well as it's parrent can be scaled, translated, and rotated, and mesh will be calculated properly.