### PR TITLE
chore: packages bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "dependencies": {
         "com.unity.burst": "1.8.2",
         "com.unity.jobs": "0.11.0-preview.6",
-        "com.andywiecko.burst.mathutils": "1.3.0",
-        "com.andywiecko.burst.collections": "1.6.0",
-        "com.andywiecko.burst.triangulator": "1.3.0",
-        "com.andywiecko.ecs": "0.2.0"
+        "com.andywiecko.burst.mathutils": "1.3.1",
+        "com.andywiecko.burst.collections": "1.7.0",
+        "com.andywiecko.burst.triangulator": "1.4.0",
+        "com.andywiecko.ecs": "0.2.1"
     }
 }


### PR DESCRIPTION
The following packages from `com.andywiecko` scope have been updated:

- `com.andywiecko.burst.mathutils`: 1.3.0 → 1.3.1
- `com.andywiecko.burst.collections`: 1.6.0 → 1.7.0
- `com.andywiecko.burst.triangulator`: 1.3.0 → 1.4.0
- `com.andywiecko.ecs`: 0.2.0 → 0.2.1