### PR TITLE
feat: create edge mesh menu item

### DIFF
--- a/Editor/EntitiesEditor.cs
+++ b/Editor/EntitiesEditor.cs
@@ -9,6 +9,9 @@ namespace andywiecko.PBD2D.Editor
     {
         private const string path = "GameObject/PBD2D/";
 
+        [MenuItem(path + nameof(EdgeMesh))]
+        public static void CreateEdgeMesh() => Create<EdgeMesh>();
+
         [MenuItem(path + nameof(TriMesh))]
         public static void CreateTriMesh() => Create<TriMesh>();
 


### PR DESCRIPTION
Adds editor menu for creating `EdgeMesh` at "GameObject/PBD2D/EdgeMesh" path.