### PR TITLE
fix: edge mesh renderer update references

### DIFF
--- a/Runtime/Components/EdgeMesh/Graphics/EdgeMeshRenderer.cs
+++ b/Runtime/Components/EdgeMesh/Graphics/EdgeMeshRenderer.cs
@@ -66,8 +66,9 @@ namespace andywiecko.PBD2D.Components
                 return;
             }
 
-            foreach (Transform r in rendererTransform)
+            for (int i = rendererTransform.childCount - 1; i >= 0; i--)
             {
+                var r = rendererTransform.GetChild(i);
                 DestroyImmediate(r.gameObject);
             }
             renderers.Clear();


### PR DESCRIPTION
Fix replaces `foreach` with `for`. It is required due to collection modification in Unity internals.